### PR TITLE
Added env indicator in title

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,1 +1,2 @@
 NSM_WWW_PATH=./www
+ENVIRONMENT_NAME=Local

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,10 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environment files
+.env
+.env.test
+.env.production
+.env.local
+.env.*.local

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/ico" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Mint Editor</title>
+    <title>__APP_TITLE__</title>
   </head>
   <body class="theme-dark">
     <div id="app"></div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,23 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [svelte()],
-})
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+
+  const baseTitle = 'Mint Editor';
+  const suffix = env.ENVIRONMENT_NAME ? ` (${env.ENVIRONMENT_NAME})` : '';
+  const fullTitle = baseTitle + suffix;
+
+  return {
+    plugins: [
+      svelte(),
+      {
+        name: 'html-transform',
+        transformIndexHtml(html) {
+          return html.replace('__APP_TITLE__', fullTitle);
+        }
+      }
+    ]
+  }
+});


### PR DESCRIPTION
Added the `ENVIRONMENT_NAME` environment variable which, if set, appears in parentheses after `Mint Editor` in the document title.

<img width="232" height="68" alt="Screenshot 2025-11-19 at 3 07 31 PM" src="https://github.com/user-attachments/assets/3aabe36d-0768-4aef-8d4b-16ed41cf1db7" />
<img width="218" height="48" alt="Screenshot 2025-11-19 at 3 07 49 PM" src="https://github.com/user-attachments/assets/dd6e0ca8-0386-4936-b017-4e27b331cd6d" />
