### PR TITLE
Basic mobile compatibility

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -67,4 +67,17 @@
         flex-grow: 1;
         min-height: 0;
     }
+
+    @media (aspect-ratio < 1/1) {
+        #upper {
+            flex-direction: column;
+            height: 100%;
+            min-width: 0;
+        }
+
+        #middle {
+            min-height: 0;
+            width: 100%;
+        }
+    }
 </style>

--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -271,6 +271,20 @@
             };
         }
     }
+
+    /**
+     * Handle touch start to prevent scrolling when drawing/interacting
+     */
+    function handleTouchStart(e: TouchEvent) {
+        e.preventDefault();
+    }
+
+    /**
+     * Handle touch move to prevent scrolling during drawing/interaction
+     */
+    function handleTouchMove(e: TouchEvent) {
+        e.preventDefault();
+    }
 </script>
 
 <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
@@ -292,6 +306,8 @@
     ondragleave={handleDragLeave}
     onscroll={handleScroll}
     onwheel={handleWheel}
+    ontouchstart={handleTouchStart}
+    ontouchmove={handleTouchMove}
 >
     <div id="interactive-area"
         role="application"
@@ -354,6 +370,7 @@
         overflow: auto;
         position: relative;
         user-select: none;
+        touch-action: none;
     }
 
     #interactive-area {

--- a/src/lib/components/DocPreview.svelte
+++ b/src/lib/components/DocPreview.svelte
@@ -175,4 +175,10 @@
         text-overflow: ellipsis;
         display: block;
     }
+
+    @media (pointer: coarse) {
+        .ellipsis {
+            opacity: 1;
+        }
+    }
 </style>

--- a/src/lib/components/LeftSidebar.svelte
+++ b/src/lib/components/LeftSidebar.svelte
@@ -186,6 +186,7 @@
         justify-content: space-between;
         width: calc(var(--s-sm) * 4 + 24);
         flex-shrink: 0;
+        overflow: scroll;
     }
 
     #tools {
@@ -227,5 +228,25 @@
 
     #swap-colors {
         cursor: pointer;
+    }
+
+    @media (aspect-ratio < 1/1) {
+        #left-sidebar, #tools {
+            flex-direction: row;
+        }
+
+        #colors {
+            flex-direction: row;
+            margin-bottom: 0;
+        }
+
+        #color-foreground {
+            margin-top: 0;
+            margin-left: -13px;
+        }
+
+        #swap-colors {
+            transform: rotate(90deg);
+        }
     }
 </style>

--- a/src/lib/components/RightSidebar.svelte
+++ b/src/lib/components/RightSidebar.svelte
@@ -23,33 +23,35 @@
 
 <div {...accordion.root} id="sidebar">
     {#each items as item}
-        <h2 {...item.heading}>
-            <button {...item.trigger}>
-                <span>
-                    {item.item.title}
-                </span>
-                <i style:transform={item.isExpanded ? 'rotate(90deg)' : ''}>
-                    <ChevronRight size={16} />
-                </i>
-            </button>
-        </h2>
-        <div {...item.content}
-             class:content={true}
-             class:closed={!item.isExpanded}
-        >
-            {#if item.item.title === 'Type'}
-                <Type />
-            {:else if item.item.title === 'Brush'}
-                <Brush />
-            {:else if item.item.title === 'Shape'}
-                <Shape />
-            {:else if item.item.title === 'Layers'}
-                <Layers />
-            {:else if item.item.title === 'Layer Styles'}
-                <LayerStyles />
-            {:else if item.item.title === 'Transform'}
-                <Transform />
-            {/if}
+        <div id="item">
+            <h2 {...item.heading}>
+                <button {...item.trigger}>
+                    <span>
+                        {item.item.title}
+                    </span>
+                    <i style:transform={item.isExpanded ? 'rotate(90deg)' : ''}>
+                        <ChevronRight size={16} />
+                    </i>
+                </button>
+            </h2>
+            <div {...item.content}
+                class:content={true}
+                class:closed={!item.isExpanded}
+            >
+                {#if item.item.title === 'Type'}
+                    <Type />
+                {:else if item.item.title === 'Brush'}
+                    <Brush />
+                {:else if item.item.title === 'Shape'}
+                    <Shape />
+                {:else if item.item.title === 'Layers'}
+                    <Layers />
+                {:else if item.item.title === 'Layer Styles'}
+                    <LayerStyles />
+                {:else if item.item.title === 'Transform'}
+                    <Transform />
+                {/if}
+            </div>
         </div>
     {/each}
 </div>
@@ -93,5 +95,17 @@
 
     .content {
         padding: var(--s-md);
+    }
+
+    @media (aspect-ratio < 1/1) {
+        #sidebar {
+            flex-direction: row;
+            width: 100%;
+            height: 200px;
+        }
+
+        .content {
+            min-width: 200px;
+        }
     }
 </style>

--- a/src/lib/components/Zoom.svelte
+++ b/src/lib/components/Zoom.svelte
@@ -81,4 +81,10 @@
     #zoom select {
         width: 80px;
     }
+
+    @media (aspect-ratio < 1/1) {
+        #zoom {
+            width: auto;
+        }
+    }
 </style>

--- a/src/lib/components/overlays/Handles.svelte
+++ b/src/lib/components/overlays/Handles.svelte
@@ -111,7 +111,6 @@
         top: -30px;
         left: 50%;
         transform: translateX(-50%);
-        pointer-events: auto;
         display: flex;
         flex-direction: column;
         align-items: center;

--- a/src/lib/scripts/tools/ellipse.svelte.ts
+++ b/src/lib/scripts/tools/ellipse.svelte.ts
@@ -9,7 +9,7 @@ import { postAction } from '../action';
 /** Ellipse tool state */
 const ellipse = $state({
     dragging: false,
-    action: 'none' as 'none' | 'create' | 'stroke'
+    action: 'create' as 'create' | 'stroke'
 });
 
 const p = {
@@ -63,7 +63,6 @@ export const ellipseTool: Tool = {
 
         if (ellipse.action === 'create' && selectedEllipseLayer) {
             ui.mode = 'select';
-            ellipse.action = 'none';
 
             postAction({
                 type: 'create',

--- a/src/lib/scripts/tools/rectangle.svelte.ts
+++ b/src/lib/scripts/tools/rectangle.svelte.ts
@@ -9,7 +9,7 @@ import { postAction } from '../action';
 /** Rectangle tool state */
 const rectangle = $state({
     dragging: false,
-    action: 'none' as 'none' | 'create' | 'corner' | 'stroke'
+    action: 'create' as 'create' | 'corner' | 'stroke'
 });
 
 const p = {
@@ -63,7 +63,6 @@ export const rectangleTool: Tool = {
 
         if (rectangle.action === 'create' && selectedEllipseLayer) {
             ui.mode = 'select';
-            rectangle.action = 'none';
 
             postAction({
                 type: 'create',

--- a/src/lib/scripts/tools/select.svelte.ts
+++ b/src/lib/scripts/tools/select.svelte.ts
@@ -46,6 +46,7 @@ export const selectTool: Tool = {
     onPointerDown: (data) => {
         select.dragging = true;
         if (!docs.selected) return;
+        setAction(data.v, data.c, data.e);
 
         if (select.action.type === 'select') {
             // traverse layers from top to bottom to find the first shape under the cursor

--- a/src/lib/scripts/tools/text.svelte.ts
+++ b/src/lib/scripts/tools/text.svelte.ts
@@ -1,7 +1,7 @@
-import type { Tool } from '.';
+import type { PointerEventData, Tool } from '.';
 import docs from '../docs.svelte';
 import ui from '../ui.svelte';
-import { createLayer, type LayerID, type TextProperties } from '../layer';
+import { createLayer, type LayerID, type TextLayer, type TextProperties } from '../layer';
 import { focusAndSelect } from '../../components/overlays/TextEdit.svelte';
 import { postAction } from '../action';
 
@@ -44,7 +44,9 @@ export const textTool: Tool = {
 
         // check if a text layer is already selected
         const selectedTextLayer = getSelectedTextLayer();
-        if (!selectedTextLayer) {
+        if (selectedTextLayer) {
+            setAction(selectedTextLayer, data);
+        } else {
             // create a new text layer
             const layer = createLayer('text', 'Text', false);
             layer.transform.matrix = new DOMMatrix().translate(data.c.x, data.c.y);
@@ -73,29 +75,7 @@ export const textTool: Tool = {
                 layer.height = Math.max(20, data.l.y);
             }
         } else {
-            // determine if cursor is near the bottom right corner for resizing
-            let point = new DOMPoint(layer.width, layer.height);
-            point = layer.transform.matrix.transformPoint(point);
-            const zoom = ui.selected?.zoom ?? 1;
-            point.x *= zoom;
-            point.y *= zoom;
-
-            const dx = data.v.x - point.x;
-            const dy = data.v.y - point.y;
-            const distance = Math.sqrt(dx * dx + dy * dy);
-
-            if (distance <= resizeHitboxSize) {
-                text.action = "resize";
-            } else if (
-                data.l.x < layer.width &&
-                data.l.y < layer.height &&
-                data.l.x > 0 &&
-                data.l.y > 0
-            ) {
-                text.action = "edit";
-            } else {
-                text.action = "none";
-            }
+            setAction(layer, data);
         }
     },
     onPointerUp: () => {
@@ -110,6 +90,39 @@ export const textTool: Tool = {
                 newLayer: { width: layer.width, height: layer.height },
             });
         }
+    }
+}
+
+/**
+ * Sets the current action (edit, resize, none) based on pointer position.
+ * @param layer The text layer.
+ * @param data Pointer event data.
+ * @returns
+ */
+function setAction(layer: TextLayer, data: PointerEventData) {
+    if (!data.l) return;
+
+    let point = new DOMPoint(layer.width, layer.height);
+    point = layer.transform.matrix.transformPoint(point);
+    const zoom = ui.selected?.zoom ?? 1;
+    point.x *= zoom;
+    point.y *= zoom;
+
+    const dx = data.v.x - point.x;
+    const dy = data.v.y - point.y;
+    const distance = Math.sqrt(dx * dx + dy * dy);
+
+    if (distance <= resizeHitboxSize) {
+        text.action = "resize";
+    } else if (
+        data.l.x < layer.width &&
+        data.l.y < layer.height &&
+        data.l.x > 0 &&
+        data.l.y > 0
+    ) {
+        text.action = "edit";
+    } else {
+        text.action = "none";
     }
 }
 


### PR DESCRIPTION
Fixes #56 

Added basic mobile compatibility. This involved:
- For portrait devices, moved the toolbar to the top and panels to the bottom
- For touch devices, disabled one-finger viewport scroll
- Enabled scroll on toolbar, for small-screen devices rotated to landscape
- Ran the `setAction` function for various tools on pointer down, not just pointer move
- Made the ellipsis for document previews always visible on mobile devices

<img width="383" height="663" alt="Screenshot 2025-11-19 at 4 59 13 PM" src="https://github.com/user-attachments/assets/181f9422-01a8-4371-9123-038498172d4b" />

