### PR TITLE
[Feat] Add vertical and horizontal snapping

### DIFF
--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -348,7 +348,13 @@
                     <DropMargin side="right" />
                 {/if}
                 <Handles />
-                {#if tool.name === 'text' && selectedLayer?.type === 'text'}
+                {#if select.snappedX}
+                    <div class="snap-line vertical"></div>
+                {/if}
+                {#if select.snappedY}
+                    <div class="snap-line horizontal"></div>
+                {/if}
+                {#if tool.name === "text" && selectedLayer?.type === "text"}
                     <TextEdit bind:layer={selectedLayer} />
                 {/if}
             </div>
@@ -398,9 +404,28 @@
         pointer-events: none;
         border: 1px solid var(--c-sec);
         border-radius: var(--r-full);
-        transform: translate(
-            calc(-50%),
-            calc(-50%)
-        );
+        transform: translate(calc(-50%), calc(-50%));
+    }
+
+    .snap-line {
+        position: absolute;
+        pointer-events: none;
+        border: 1px dashed var(--c-acc);
+    }
+
+    .snap-line.vertical {
+        left: 50%;
+        top: 0;
+        bottom: 0;
+        width: 1px;
+        transform: translateX(-0.5px);
+    }
+
+    .snap-line.horizontal {
+        top: 50%;
+        left: 0;
+        right: 0;
+        height: 1px;
+        transform: translateY(-0.5px);
     }
 </style>

--- a/src/lib/scripts/tools/select.svelte.ts
+++ b/src/lib/scripts/tools/select.svelte.ts
@@ -147,15 +147,14 @@ export const selectTool: Tool = {
                     y: docs.selected!.height / 2,
                 };
 
-                // snap
                 let snappedCenter = { ...proposedCenter };
                 select.snappedX = false;
                 select.snappedY = false;
-                if (Math.abs(proposedCenter.x - canvasCenter.x) < snapThreshold) {
+                if (Math.abs(proposedCenter.x - canvasCenter.x) < snapThreshold / ui.selected!.zoom) {
                     snappedCenter.x = canvasCenter.x;
                     select.snappedX = true;
                 }
-                if (Math.abs(proposedCenter.y - canvasCenter.y) < snapThreshold) {
+                if (Math.abs(proposedCenter.y - canvasCenter.y) < snapThreshold / ui.selected!.zoom) {
                     snappedCenter.y = canvasCenter.y;
                     select.snappedY = true;
                 }

--- a/src/lib/scripts/tools/select.svelte.ts
+++ b/src/lib/scripts/tools/select.svelte.ts
@@ -1,5 +1,5 @@
 import docs, { matrixToTransformComponents } from "../docs.svelte";
-import ui, { type Bounds } from "../ui.svelte";
+import ui, { type Bounds, getBoundsCenter } from "../ui.svelte";
 import type { Tool, Point } from ".";
 import { translateLayerBy, type Layer, type LayerID } from "../layer";
 import { postAction, type PostAction } from "../action";
@@ -8,6 +8,7 @@ import { setPreviousRotation } from "../ui.svelte";
 const scaleHandleHitboxSize = 5;
 const rotateHandleHitboxSize = 5;
 const rotateHandleOffset = 25;
+const snapThreshold = 10;
 
 /** The scale directions represented by each scale handle */
 export type ScaleDirection = 'n' | 's' | 'e' | 'w' | 'ne' | 'nw' | 'se' | 'sw';
@@ -26,11 +27,15 @@ export type SelectAction = {
 
 /** Select tool state */
 const select: {
-    action: SelectAction,
-    dragging: boolean,
+    action: SelectAction;
+    dragging: boolean;
+    snappedX: boolean;
+    snappedY: boolean;
 } = $state({
     action: { type: 'select' },
-    dragging: false
+    dragging: false,
+    snappedX: false,
+    snappedY: false,
 });
 
 const initial = {
@@ -130,7 +135,35 @@ export const selectTool: Tool = {
                 const dx = data.c.x - initial.c.x;
                 const dy = data.c.y - initial.c.y;
 
-                translateLayers(ui.selectedLayers, dx, dy);
+                // calc new center
+                const initialCenter = getBoundsCenter(initial.bounds!);
+                const proposedCenter = {
+                    x: initialCenter.x + dx,
+                    y: initialCenter.y + dy,
+                };
+
+                const canvasCenter = {
+                    x: docs.selected!.width / 2,
+                    y: docs.selected!.height / 2,
+                };
+
+                // snap
+                let snappedCenter = { ...proposedCenter };
+                select.snappedX = false;
+                select.snappedY = false;
+                if (Math.abs(proposedCenter.x - canvasCenter.x) < snapThreshold) {
+                    snappedCenter.x = canvasCenter.x;
+                    select.snappedX = true;
+                }
+                if (Math.abs(proposedCenter.y - canvasCenter.y) < snapThreshold) {
+                    snappedCenter.y = canvasCenter.y;
+                    select.snappedY = true;
+                }
+
+                const snappedDx = snappedCenter.x - initialCenter.x;
+                const snappedDy = snappedCenter.y - initialCenter.y;
+
+                translateLayers(ui.selectedLayers, snappedDx, snappedDy);
             } else if (select.action.type === 'scale') {
                 const dir = select.action.direction;
 
@@ -187,10 +220,14 @@ export const selectTool: Tool = {
         } else {
             // determine action based on mouse position
             setAction(data.v, data.c, data.e);
+            select.snappedX = false;
+            select.snappedY = false;
         }
     },
     onPointerUp: (data) => {
         select.dragging = false;
+        select.snappedX = false;
+        select.snappedY = false;
 
         // if action is scale/move/rotate, record post-action state
         if (docs.selected) {


### PR DESCRIPTION
How it works:

While dragging items around the canvas, check if the center of your selection is close to the canvas center. If it gets within 10px horizontally or vertically, it will snap the selection center to align with the canvas center


https://github.com/user-attachments/assets/dda1038f-4484-44ba-af8d-09b2ddde4a10

